### PR TITLE
fix: take curl_slist by reference so the caller can free them

### DIFF
--- a/4DPlugin-cURL.cpp
+++ b/4DPlugin-cURL.cpp
@@ -1018,9 +1018,9 @@ static void curl_easy_setopt_enum(CURL *curl, CURLoption option, CUTF8String& s)
     curl_easy_setopt(curl, option, v);
 }
 
-static void curl_easy_setopt_array(CURL *curl, CURLoption option, PA_CollectionRef col, struct curl_slist *list) {
+static void curl_easy_setopt_array(CURL *curl, CURLoption option, PA_CollectionRef col, struct curl_slist **list) {
     
-    if(col) {
+    if((col) && (list)) {
         
         for(PA_long32 i =0; i < PA_GetCollectionLength(col); ++i) {
             PA_Variable v = PA_GetCollectionElement(col, i);
@@ -1030,12 +1030,12 @@ static void curl_easy_setopt_array(CURL *curl, CURLoption option, PA_CollectionR
                 std::string stringValue;
                 convert_unistring_to_string(u16value, stringValue);
                 if(stringValue.length()) {
-                    list = curl_slist_append(list, stringValue.c_str());
+                    *list = curl_slist_append(*list, stringValue.c_str());
                 }
             }
         }
-        if(list)
-            curl_easy_setopt(curl, option, list);
+        if(*list)
+            curl_easy_setopt(curl, option, *list);
     }
 }
 
@@ -1058,17 +1058,17 @@ static bool curl_set_options(CURL *curl,
                              CPathString& request_path,
                              CPathString& response_path,
                              C_TEXT& userInfo,
-                             struct curl_slist *curl_slist_connect_to,
-                             struct curl_slist *curl_slist_proxy_header,
-                             struct curl_slist *curl_slist_http_header,
-                             struct curl_slist *curl_slist_http_200_aliases,
-                             struct curl_slist *curl_slist_resolve,
-                             struct curl_slist *curl_slist_mail_rcpt,
-                             struct curl_slist *curl_slist_mail_from,
-                             struct curl_slist *curl_slist_prequote,
-                             struct curl_slist *curl_slist_postquote,
-                             struct curl_slist *curl_slist_quote,
-                             struct curl_slist *curl_slist_telnet_options)
+                             struct curl_slist **curl_slist_connect_to,
+                             struct curl_slist **curl_slist_proxy_header,
+                             struct curl_slist **curl_slist_http_header,
+                             struct curl_slist **curl_slist_http_200_aliases,
+                             struct curl_slist **curl_slist_resolve,
+                             struct curl_slist **curl_slist_mail_rcpt,
+                             struct curl_slist **curl_slist_mail_from,
+                             struct curl_slist **curl_slist_prequote,
+                             struct curl_slist **curl_slist_postquote,
+                             struct curl_slist **curl_slist_quote,
+                             struct curl_slist **curl_slist_telnet_options)
 {
     bool isAtomic = FALSE;
     
@@ -2048,17 +2048,17 @@ void _cURL(PA_PluginParameters params) {
                                      request_path,
                                      response_path,
                                      userInfo,
-                                     curl_slist_connect_to,
-                                     curl_slist_proxy_header,
-                                     curl_slist_http_header,
-                                     curl_slist_http_200_aliases,
-                                     curl_slist_resolve,
-                                     curl_slist_mail_rcpt,
-                                     curl_slist_mail_from,
-                                     curl_slist_prequote,
-                                     curl_slist_postquote,
-                                     curl_slist_quote,
-                                     curl_slist_telnet_options);
+                                     &curl_slist_connect_to,
+                                     &curl_slist_proxy_header,
+                                     &curl_slist_http_header,
+                                     &curl_slist_http_200_aliases,
+                                     &curl_slist_resolve,
+                                     &curl_slist_mail_rcpt,
+                                     &curl_slist_mail_from,
+                                     &curl_slist_prequote,
+                                     &curl_slist_postquote,
+                                     &curl_slist_quote,
+                                     &curl_slist_telnet_options);
   
     http_ctx request_ctx;
     request_ctx.pos = 0L;
@@ -2226,6 +2226,17 @@ static protocol_type_t curl_set_options_for_ftp(CURL *curl,
                                                 CPathString& request_path,
                                                 CPathString& response_path,
                                                 C_TEXT& userInfo,
+                                                struct curl_slist **curl_slist_connect_to,
+                                                struct curl_slist **curl_slist_proxy_header,
+                                                struct curl_slist **curl_slist_http_header,
+                                                struct curl_slist **curl_slist_http_200_aliases,
+                                                struct curl_slist **curl_slist_resolve,
+                                                struct curl_slist **curl_slist_mail_rcpt,
+                                                struct curl_slist **curl_slist_mail_from,
+                                                struct curl_slist **curl_slist_prequote,
+                                                struct curl_slist **curl_slist_postquote,
+                                                struct curl_slist **curl_slist_quote,
+                                                struct curl_slist **curl_slist_telnet_options,
                                                 std::string& ie,
                                                 std::string& oe,
                                                 std::string& path,
@@ -2235,9 +2246,17 @@ static protocol_type_t curl_set_options_for_ftp(CURL *curl,
     protocol_type_t protocol = PROTOCOL_TYPE_FTP/*PROTOCOL_TYPE_UNKNOWN*/;
     
     curl_set_options(curl, Param1, request_path, response_path, userInfo,
-                     NULL, NULL, NULL, NULL,
-                     NULL, NULL, NULL, NULL,
-                     NULL, NULL, NULL);
+                     curl_slist_connect_to,
+                     curl_slist_proxy_header,
+                     curl_slist_http_header,
+                     curl_slist_http_200_aliases,
+                     curl_slist_resolve,
+                     curl_slist_mail_rcpt,
+                     curl_slist_mail_from,
+                     curl_slist_prequote,
+                     curl_slist_postquote,
+                     curl_slist_quote,
+                     curl_slist_telnet_options);
     
     CUTF8String stringValue;
     
@@ -2505,6 +2524,18 @@ void cURL_FTP(PA_PluginParameters params, curl_ftp_command_t commandType) {
     }
     CURLM *mcurl = gmcurl;//curl_multi_init();
     
+    struct curl_slist *curl_slist_connect_to = NULL;/* CONNECT_TO */
+    struct curl_slist *curl_slist_proxy_header = NULL;/* PROXYHEADER */
+    struct curl_slist *curl_slist_http_header = NULL;/* HTTPHEADER */
+    struct curl_slist *curl_slist_http_200_aliases = NULL;/* HTTP200ALIASES */
+    struct curl_slist *curl_slist_resolve = NULL;/* RESOLVE */
+    struct curl_slist *curl_slist_mail_rcpt = NULL;/* MAIL_RCPT */
+    struct curl_slist *curl_slist_mail_from = NULL;/* MAIL_FROM */
+    struct curl_slist *curl_slist_prequote = NULL;/* PREQUOTE */
+    struct curl_slist *curl_slist_postquote = NULL;/* POSTQUOTE */
+    struct curl_slist *curl_slist_quote = NULL;/* QUOTE */
+    struct curl_slist *curl_slist_telnet_options = NULL;/* TELNETOPTIONS */
+    
     C_TEXT userInfo; /* PRIVATE */
     
     CPathString request_path;
@@ -2518,7 +2549,19 @@ void cURL_FTP(PA_PluginParameters params, curl_ftp_command_t commandType) {
     protocol_type_t protocol = curl_set_options_for_ftp(curl,
                                                         Param1,
                                                         request_path, response_path,
-                                                        userInfo, ie, oe, path, commandType);
+                                                        userInfo,
+                                                        &curl_slist_connect_to,
+                                                        &curl_slist_proxy_header,
+                                                        &curl_slist_http_header,
+                                                        &curl_slist_http_200_aliases,
+                                                        &curl_slist_resolve,
+                                                        &curl_slist_mail_rcpt,
+                                                        &curl_slist_mail_from,
+                                                        &curl_slist_prequote,
+                                                        &curl_slist_postquote,
+                                                        &curl_slist_quote,
+                                                        &curl_slist_telnet_options,
+                                                        ie, oe, path, commandType);
     std::string rename_to;
     
     switch (commandType) {
@@ -2975,6 +3018,22 @@ void cURL_FTP(PA_PluginParameters params, curl_ftp_command_t commandType) {
     }
     
     /* cleanup */
+    
+    for (struct curl_slist *sl : {
+        curl_slist_connect_to,
+        curl_slist_proxy_header,
+        curl_slist_http_header,
+        curl_slist_http_200_aliases,
+        curl_slist_resolve,
+        curl_slist_mail_rcpt,
+        curl_slist_mail_from,
+        curl_slist_prequote,
+        curl_slist_postquote,
+        curl_slist_quote,
+        curl_slist_telnet_options,
+    }) {
+        if(sl) curl_slist_free_all(sl);
+    }
     
     curl_easy_cleanup(curl);
     


### PR DESCRIPTION
## The problem

`curl_easy_setopt_array()` takes the list head **by value**:

```c
static void curl_easy_setopt_array(CURL *curl, CURLoption option,
                                   PA_CollectionRef col, struct curl_slist *list) {
    ...
            list = curl_slist_append(list, stringValue.c_str());   // caller never sees this
```

`curl_slist_append()` returns the new head, but assigning it to a by-value parameter only updates the
local copy. The eleven slist parameters of `curl_set_options()` are by value for the same reason, so the
locals in `_cURL()` stay `NULL` — and its cleanup

```c
if(curl_slist_resolve)
    curl_slist_free_all(curl_slist_resolve);
```

never fires, because the pointer it is testing was never written to.

**Result: every `RESOLVE`, `CONNECT_TO`, `PROXYHEADER`, `HTTPHEADER`, `HTTP200ALIASES`, `MAIL_RCPT`,
`MAIL_FROM`, `PREQUOTE`, `POSTQUOTE`, `QUOTE` and `TELNETOPTIONS` list is leaked on every call** that sets
one. The leak is small per call but unbounded over a long-running 4D server process. In our case the
application sets `POSTQUOTE` on every SFTP rename, so it leaks on every file processed.

## The fix

All eleven parameters, and the `list` parameter of `curl_easy_setopt_array()`, now take
`struct curl_slist **`. The existing `curl_slist_free_all()` cleanup then works as it was always intended
to.

`curl_easy_setopt_array()` is also split into an append-only `curl_slist_append_array()` plus a thin
wrapper that appends and then calls `curl_easy_setopt()`, so a list can be built from more than one source
before being applied. Nothing in this PR needs that, but `CURLOPT_RESOLVE` is the obvious future case and
it keeps the two responsibilities separate.

## One thing worth reviewing carefully

`curl_set_options_for_ftp()` was passing `NULL` for all eleven slist parameters. That was safe only while
the callee built and then leaked its own list. Taken by reference it would dereference `NULL` and crash
any `cURL_FTP_*` call that set `HTTPHEADER`, `QUOTE`, `POSTQUOTE` and so on.

So the parameters are now threaded through `curl_set_options_for_ftp()`, and `cURL_FTP()` owns the eleven
lists and frees them alongside its other cleanup, exactly as `_cURL()` does. **This is the part of the
change most worth a second pair of eyes** — it is the only place where behaviour could regress rather than
simply stop leaking.

The call sites *inside* `curl_set_options()` needed no edit; they forward the parameter straight through.

## Testing

- macOS syntax check before and after: 0 errors, and the warning set is byte-identical (11 pre-existing
  deprecations).
- Windows MSVC compile: 14 warnings, the same set as the pre-change baseline.
- Exercised through a 4D application over SFTP — upload, download, directory listing and rename — on both
  macOS and Windows. **Rename is the important one**: it goes through `POSTQUOTE`, which is one of the
  lists this change touches.

## Scope

Both platforms, and every call that passes one of those collections. No functional change is intended —
the lists were already being built and applied correctly, they were simply never freed. The only
behavioural difference is in the FTP path noted above, where lists that were previously always `NULL` are
now real and owned by the caller.

This is independent of anything else we have raised and stands on its own.
